### PR TITLE
Renamed local_ansible_data_path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"
 # List of users to configure IntelliJ IDEA for
 users: []
 
-# path for Ansible to store downloaded files
-local_ansible_data_path: '/tmp/ansible/data'
+# Directory to store files downloaded for IntelliJ IDEA installation
+intellij_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
 
 # SHA256 sum for the redistributable package
 intellij_redis_sha256sum: d1cd3f9fd650c00ba85181da6d66b4b80b8e48ce5f4f15b5f4dc67453e96a179

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,5 +21,5 @@ intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"
 # List of users to configure IntelliJ IDEA for
 users: []
 
-# path for Ansible to store downloaded files
-local_ansible_data_path: '/tmp/ansible/data'
+# Directory to store files downloaded for IntelliJ IDEA installation
+intellij_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,16 +24,16 @@
     that:
       - "intellij_redis_sha256sum not in (None, '')"
 
-- name: create local Ansible data directory
+- name: create download directory
   file:
     state: directory
     mode: 'u=rwx,go=rx'
-    dest: "{{ local_ansible_data_path }}"
+    dest: "{{ intellij_download_dir }}"
 
 - name: download IntelliJ IDEA
   get_url:
     url: "{{ intellij_mirror }}/{{ intellij_redis_filename }}"
-    dest: "{{ local_ansible_data_path }}/{{ intellij_redis_filename }}"
+    dest: "{{ intellij_download_dir }}/{{ intellij_redis_filename }}"
     sha256sum: "{{ intellij_redis_sha256sum }}"
     force: false
     use_proxy: true
@@ -53,7 +53,7 @@
   become: yes
   command: >
     /bin/tar --extract --gunzip --strip-components=1
-    --file '{{ local_ansible_data_path }}/{{ intellij_redis_filename }}'
+    --file '{{ intellij_download_dir }}/{{ intellij_redis_filename }}'
     --directory '{{ intellij_install_dir }}'
   args:
     creates: "{{ intellij_install_dir }}/bin"


### PR DESCRIPTION
Renamed local_ansible_data_path to intellij_download_dir as it was potentially misleading.

Enhancement: resolves #7