### PR TITLE
Moved default intellij_download_dir under user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"
 users: []
 
 # Directory to store files downloaded for IntelliJ IDEA installation
-intellij_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+intellij_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
 
 # SHA256 sum for the redistributable package
 intellij_redis_sha256sum: d1cd3f9fd650c00ba85181da6d66b4b80b8e48ce5f4f15b5f4dc67453e96a179

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,4 +22,4 @@ intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"
 users: []
 
 # Directory to store files downloaded for IntelliJ IDEA installation
-intellij_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+intellij_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"


### PR DESCRIPTION
Changed default for `intellij_download_dir` from `/tmp/ansible/data` to `~/.ansible/tmp/downloads`.

Enhancement: resolves #8