### PR TITLE
Removed "intellij_" prefix from IntelliJ facts

### DIFF
--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -1,3 +1,3 @@
 [general]
-intellij_home={{ intellij_install_dir }}
-intellij_desktop_file=/usr/share/applications/{{ intellij_desktop_filename }}
+home={{ intellij_install_dir }}
+desktop_file=/usr/share/applications/{{ intellij_desktop_filename }}


### PR DESCRIPTION
It was unnecessarily verbose.

Enhancement: resolves #12