### PR TITLE
Updated default value for maven_home

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ intellij_install_dir: /opt/idea/idea-{{ intellij_edition }}-{{ intellij_version 
 intellij_default_jdk_home: "{{ ansible_local.java.general.java_home }}"
 
 # Location of the default Apache Maven installation for IntelliJ IDEA projects
-intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"
+intellij_default_maven_home: "{{ ansible_local.maven.general.home }}"
 
 # List of users to configure IntelliJ IDEA for
 users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ intellij_install_dir: /opt/idea/idea-{{ intellij_edition }}-{{ intellij_version 
 intellij_default_jdk_home: "{{ ansible_local.java.general.java_home }}"
 
 # Location of the default Apache Maven installation for IntelliJ IDEA projects
-intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"
+intellij_default_maven_home: "{{ ansible_local.maven.general.home }}"
 
 # List of users to configure IntelliJ IDEA for
 users: []


### PR DESCRIPTION
Changed to match fact in version `3.0.0` of `gantsign.maven`.

Enhancement: resolves #15