### PR TITLE
Updated default value for java_home

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ intellij_edition: community
 intellij_install_dir: /opt/idea/idea-{{ intellij_edition }}-{{ intellij_version }}
 
 # Location of the default JDK for IntelliJ IDEA projects
-intellij_default_jdk_home: "{{ ansible_local.java.general.java_home }}"
+intellij_default_jdk_home: "{{ ansible_local.java.general.home }}"
 
 # Location of the default Apache Maven installation for IntelliJ IDEA projects
 intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ intellij_edition: community
 intellij_install_dir: /opt/idea/idea-{{ intellij_edition }}-{{ intellij_version }}
 
 # Location of the default JDK for IntelliJ IDEA projects
-intellij_default_jdk_home: "{{ ansible_local.java.general.java_home }}"
+intellij_default_jdk_home: "{{ ansible_local.java.general.home }}"
 
 # Location of the default Apache Maven installation for IntelliJ IDEA projects
 intellij_default_maven_home: "{{ ansible_local.maven.general.maven_home }}"


### PR DESCRIPTION
Changed to match fact in version `2.0.0` of `gantsign.java`.

Enhancement: resolves #16