### PR TITLE
Added desktop_filename fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ This role exports the following Ansible facts for use by other roles:
 
     * e.g. `/opt/idea/idea-community-2016.2.2`
     
+* `ansible_local.intellij.general.desktop_filename`
+
+    * e.g. `jetbrains-idea-ce.desktop`
+
 * `ansible_local.intellij.general.desktop_file`
 
     * e.g. `/usr/share/applications/jetbrains-idea-ce.desktop`

--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -2,4 +2,5 @@
 
 [general]
 home={{ intellij_install_dir }}
+desktop_filename={{ intellij_desktop_filename }}
 desktop_file=/usr/share/applications/{{ intellij_desktop_filename }}


### PR DESCRIPTION
To configure the Unity launcher you need the name of the desktop file rather than the absolute path.

Enhancement: resolves #29