### PR TITLE
Suppress warning about using tar

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,8 @@
     --directory '{{ intellij_install_dir }}'
   args:
     creates: "{{ intellij_install_dir }}/bin"
+    # Suppress: [WARNING]: Consider using unarchive module rather than running tar
+    warn: no
 
 - name: create bin link
   become: yes


### PR DESCRIPTION
Using tar to maintain support for Ansible 1.9 while using `--strip-components`.