### PR TITLE
Change README.md to install Checkstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ and code style):
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
           intellij_active_codestyle: GoogleStyle
           intellij_plugins:
-            - google-java-format
+            - CheckStyle-IDEA
 ```
 
 Role Facts


### PR DESCRIPTION
The intellij-java-google-style.xml formatting doesn't match google-java-format so it's misleading to users to suggest using them both at the same time.