### PR TITLE
Fixed intellij_download_dir path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,4 +22,4 @@ intellij_default_maven_home: "{{ ansible_local.maven.general.home }}"
 users: []
 
 # Directory to store files downloaded for IntelliJ IDEA installation
-intellij_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
+intellij_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"


### PR DESCRIPTION
Was using the home directory of the local user rather than the remote user.