### PR TITLE
Fixed plugin ID whitespace

### DIFF
--- a/templates/install-intellij-plugins.sh.j2
+++ b/templates/install-intellij-plugins.sh.j2
@@ -15,8 +15,10 @@ declare -A plugin_file_map
 download_plugin() {
     plugin_id=$1
     plugin_manager_url='https://plugins.jetbrains.com/pluginManager/'
-    plugin_manager_plugin_url="$plugin_manager_url?action=download&build=$buid_number&id=$plugin_id"
-    location_header=$(curl --silent --head "$plugin_manager_plugin_url" | dos2unix | grep -i --color=never 'Location') || return 2
+    plugin_manager_plugin_url="$plugin_manager_url?action=download&build=$buid_number"
+    location_header=$(curl --silent --data-urlencode "id=$plugin_id" --get \
+        --head "$plugin_manager_plugin_url" | dos2unix \
+        | grep -i --color=never 'Location') || return 2
     plugin_url=$(printf "$location_header" | awk '{print $2}') || return 2
     file_name=$(printf "$plugin_url" | sed --regexp-extended 's:^.*/([0-9]+)/([0-9]+)/([^/]+)$:\1-\2-\3:') || return 2
     file_path=$download_dir/$file_name
@@ -34,7 +36,7 @@ download_plugin() {
 {{ plugins.extend(user.intellij_plugins) }}
 {% endif %}
 {% endfor %}
-while read plugin_id ; do download_plugin $plugin_id || exit 2; done <<'EOF'
+while read plugin_id ; do download_plugin "$plugin_id" || exit 2; done <<'EOF'
 {% for plugin in (plugins | unique) %}{{ plugin }}
 {% endfor %}
 EOF

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -57,6 +57,7 @@
           intellij_active_codestyle: GoogleStyle
           intellij_plugins:
             - google-java-format
+            - Lombook Plugin
         - username: test_usr2
           intellij_disabled_plugins:
           intellij_plugins:

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -27,9 +27,12 @@ def test_config_files(Command, File, file_path, expected_text):
     assert File(config_home + '/' + file_path).contains(expected_text)
 
 
-def test_plugin_installed(File):
-    path = '/home/test_usr/.IdeaIC2016.2/config/plugins/google-java-format'
-    plugin_dir = File(path)
+@pytest.mark.parametrize('plugin_dir_path', [
+    '/home/test_usr/.IdeaIC2016.2/config/plugins/google-java-format',
+    '/home/test_usr/.IdeaIC2016.2/config/plugins/lombok-plugin'
+])
+def test_plugins_installed(File, plugin_dir_path):
+    plugin_dir = File(plugin_dir_path)
 
     assert plugin_dir.exists
     assert plugin_dir.is_directory


### PR DESCRIPTION
Plugin IDs containing whitespace now install correctly.

Enhancement: resolves #55