### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ intellij_version: '2016.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
-intellij_mirror: "http://download.jetbrains.com/idea"
+intellij_mirror: 'http://download.jetbrains.com/idea'
 
 # Edition to install (community or ultimate)
 intellij_edition: community
@@ -60,10 +60,10 @@ intellij_edition: community
 intellij_install_dir: /opt/idea/idea-{{ intellij_edition }}-{{ intellij_version }}
 
 # Location of the default JDK for IntelliJ IDEA projects
-intellij_default_jdk_home: "{{ ansible_local.java.general.home }}"
+intellij_default_jdk_home: '{{ ansible_local.java.general.home }}'
 
 # Location of the default Apache Maven installation for IntelliJ IDEA projects
-intellij_default_maven_home: "{{ ansible_local.maven.general.home }}"
+intellij_default_maven_home: '{{ ansible_local.maven.general.home }}'
 
 # List of users to configure IntelliJ IDEA for
 users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ intellij_version: '2016.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
-intellij_mirror: "http://download.jetbrains.com/idea"
+intellij_mirror: 'http://download.jetbrains.com/idea'
 
 # Edition to install (community or ultimate)
 intellij_edition: community
@@ -13,13 +13,13 @@ intellij_edition: community
 intellij_install_dir: /opt/idea/idea-{{ intellij_edition }}-{{ intellij_version }}
 
 # Deprecated: split into intellij_jdk_home and users.intellij_jdks
-intellij_default_jdk_home: "{{ ansible_local.java.general.home }}"
+intellij_default_jdk_home: '{{ ansible_local.java.general.home }}'
 
 # Location of the JDK for running IntelliJ IDEA
-intellij_jdk_home: "{{ intellij_default_jdk_home }}"
+intellij_jdk_home: '{{ intellij_default_jdk_home }}'
 
 # Location of the default Apache Maven installation for IntelliJ IDEA projects
-intellij_default_maven_home: "{{ ansible_local.maven.general.home }}"
+intellij_default_maven_home: '{{ ansible_local.maven.general.home }}'
 
 # List of users to configure IntelliJ IDEA for
 users: []

--- a/tasks/configure-code-style.yml
+++ b/tasks/configure-code-style.yml
@@ -2,33 +2,33 @@
 - name: create IntelliJ IDEA user options directory
   become: yes
   file:
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/options"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/options'
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rwx,o=rx'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: configure CodeStyleSettingsManager
   become: yes
   template:
     src: code.style.schemes.j2
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/options/code.style.schemes"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/options/code.style.schemes'
     force: no
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rw,o=r'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
   when: item.intellij_active_codestyle is defined
 
 - name: configure CodeStyleSchemeSettings
   become: yes
   template:
     src: code.style.schemes.xml.j2
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/options/code.style.schemes.xml"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/options/code.style.schemes.xml'
     force: no
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rw,o=r'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
   when: item.intellij_active_codestyle is defined

--- a/tasks/configure-disabled-plugins.yml
+++ b/tasks/configure-disabled-plugins.yml
@@ -2,21 +2,21 @@
 - name: create IntelliJ IDEA user config directory
   become: yes
   file:
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config'
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rwx,o=rx'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: configure disabled plugins
   become: yes
   template:
     src: disabled_plugins.txt.j2
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/disabled_plugins.txt"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/disabled_plugins.txt'
     force: no
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rw,o=r'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
   when: "item.intellij_disabled_plugins is defined and item.intellij_disabled_plugins not in (None, '', omit)"

--- a/tasks/configure-jdk-table.yml
+++ b/tasks/configure-jdk-table.yml
@@ -2,28 +2,28 @@
 - name: create IntelliJ IDEA user options directory
   become: yes
   file:
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/options"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/options'
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rwx,o=rx'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: create JDK table
   become: yes
   template:
     src: jdk.table.xml.j2
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/options/jdk.table.xml"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/options/jdk.table.xml'
     force: no
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rw,o=r'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: write JDK stylesheets
   template:
-    src: "{{ item }}"
-    dest: "{{ intellij_tmp_dir }}/{{ item }}"
+    src: '{{ item }}'
+    dest: '{{ intellij_tmp_dir }}/{{ item }}'
     mode: 'ug=rwx,o=r'
   with_items:
     - jdk-1.6-openjdk.xsl
@@ -51,7 +51,7 @@
 - name: write JDK table script
   template:
     src: set-jdk.sh.j2
-    dest: "{{ intellij_tmp_dir }}/set-jdk.sh"
+    dest: '{{ intellij_tmp_dir }}/set-jdk.sh'
     mode: 'ug=rwx,o=r'
 
 - name: set fallback JDK
@@ -63,7 +63,7 @@
     - skip_ansible_lint
   shell: |
     {{ intellij_tmp_dir }}/set-jdk.sh '{{ item.username }}' default '{{ intellij_default_jdk_home }}'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
   register: fallback
   changed_when: fallback.rc == 0
   failed_when: fallback.rc >= 2
@@ -79,7 +79,7 @@
   shell: |
     {{ intellij_tmp_dir }}/set-jdk.sh '{{ item.0.username }}' '{{ item.1.name }}' '{{ item.1.home }}'
   with_subelements:
-    - "{{ users }}"
+    - '{{ users }}'
     - intellij_jdks
     - skip_missing: yes
   register: jdk

--- a/tasks/configure-project-defaults.yml
+++ b/tasks/configure-project-defaults.yml
@@ -2,25 +2,25 @@
 - name: create IntelliJ IDEA user options directory
   become: yes
   file:
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/options"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/options'
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rwx,o=rx'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: assert intellij_default_jdk specified
   assert:
     that:
       - "item.intellij_default_jdk not in (None, '')"
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
   when: "item.intellij_jdks is defined and item.intellij_jdks not in ([], None, '', omit)"
 
 - name: assert intellij_default_jdk valid
   assert:
     that:
       - "item.intellij_default_jdk in (item.intellij_jdks | map(attribute='name'))"
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
   when: "item.intellij_jdks is defined and item.intellij_jdks not in ([], None, '', omit)"
 
 - name: query Java specification version
@@ -36,7 +36,7 @@
       "/application/component[@name='ProjectJdkTable']/jdk[name/@value=\"$jdk_name\"]/homePath/@value" \
       $jdk_table)
     $java_home/bin/jrunscript -e "print(java.lang.System.getProperty('java.specification.version'))"
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
   always_run: yes
   register: java_specification_version_result
   changed_when: no
@@ -45,9 +45,9 @@
   become: yes
   template:
     src: project.default.xml.j2
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/options/project.default.xml"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/options/project.default.xml'
     force: no
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rw,o=r'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'

--- a/tasks/install-code-styles.yml
+++ b/tasks/install-code-styles.yml
@@ -2,23 +2,23 @@
 - name: create IntelliJ IDEA user codestyles directory
   become: yes
   file:
-    dest: "~{{ item.username }}/{{ intellij_user_dir }}/config/codestyles"
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/codestyles'
     state: directory
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     mode: 'ug=rwx,o=rx'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: download codestyles
   get_url:
-    url: "{{ item.1.url }}"
+    url: '{{ item.1.url }}'
     dest: "{{ intellij_download_dir }}/{{ item.1.url | regex_replace('^.*/([^/]+)$', '\\1') }}"
     force: no
     use_proxy: yes
     validate_certs: yes
     mode: 'u=rw,go=r'
   with_subelements:
-    - "{{ users }}"
+    - '{{ users }}'
     - intellij_codestyles
     - skip_missing: yes
 
@@ -36,7 +36,7 @@
   args:
     executable: /bin/bash
   with_subelements:
-    - "{{ users }}"
+    - '{{ users }}'
     - intellij_codestyles
     - skip_missing: yes
   register: codestyle_copy
@@ -46,12 +46,12 @@
 - name: set codestyles permissions
   become: yes
   file:
-    path: "~{{ item.0.username }}/{{ intellij_user_dir }}/config/codestyles/{{ item.1.name }}.xml"
+    path: '~{{ item.0.username }}/{{ intellij_user_dir }}/config/codestyles/{{ item.1.name }}.xml'
     state: file
-    owner: "{{ item.0.username }}"
-    group: "{{ item.0.username }}"
+    owner: '{{ item.0.username }}'
+    group: '{{ item.0.username }}'
     mode: 'ug=rw,o=r'
   with_subelements:
-    - "{{ users }}"
+    - '{{ users }}'
     - intellij_codestyles
     - skip_missing: yes

--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -25,7 +25,7 @@
   become: yes
   template:
     src: install-intellij-plugins.sh.j2
-    dest: "{{ intellij_plugin_install_script }}"
+    dest: '{{ intellij_plugin_install_script }}'
     owner: root
     group: root
     mode: 'u=rwx,go='
@@ -44,7 +44,7 @@
 
 - name: install plugins
   become: yes
-  command: "{{ intellij_plugin_install_script }}"
+  command: '{{ intellij_plugin_install_script }}'
   register: plugins_result
   changed_when: 'plugins_result.rc == 0'
   failed_when: 'plugins_result.rc >= 2'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,13 +11,13 @@
       - "intellij_edition in ('community', 'ultimate')"
 
 - name: load edition vars
-  include_vars: "../vars/editions/{{ intellij_edition }}.yml"
+  include_vars: '../vars/editions/{{ intellij_edition }}.yml'
 
 - name: load version vars
   with_first_found:
-    - "../vars/versions/{{ intellij_version }}-{{ intellij_edition }}.yml"
+    - '../vars/versions/{{ intellij_version }}-{{ intellij_edition }}.yml'
     - ../vars/versions/default.yml
-  include_vars: "{{ item }}"
+  include_vars: '{{ item }}'
 
 - name: assert version vars
   assert:
@@ -28,17 +28,17 @@
   file:
     state: directory
     mode: 'u=rwx,go=rx'
-    dest: "{{ intellij_download_dir }}"
+    dest: '{{ intellij_download_dir }}'
 
 - name: download IntelliJ IDEA
   get_url:
-    url: "{{ intellij_mirror }}/{{ intellij_redis_filename }}"
-    dest: "{{ intellij_download_dir }}/{{ intellij_redis_filename }}"
-    sha256sum: "{{ intellij_redis_sha256sum }}"
+    url: '{{ intellij_mirror }}/{{ intellij_redis_filename }}'
+    dest: '{{ intellij_download_dir }}/{{ intellij_redis_filename }}'
+    sha256sum: '{{ intellij_redis_sha256sum }}'
     force: no
     use_proxy: yes
     validate_certs: yes
-    timeout: "{{ intellij_idea_download_timeout_seconds }}"
+    timeout: '{{ intellij_idea_download_timeout_seconds }}'
     mode: 'u=rw,go=r'
 
 - name: create IntelliJ IDEA installation directory
@@ -48,7 +48,7 @@
     owner: root
     group: root
     mode: 'u=rwx,go=rx'
-    dest: "{{ intellij_install_dir }}"
+    dest: '{{ intellij_install_dir }}'
 
 - name: install IntelliJ IDEA
   become: yes
@@ -62,14 +62,14 @@
     --file '{{ intellij_download_dir }}/{{ intellij_redis_filename }}'
     --directory '{{ intellij_install_dir }}'
   args:
-    creates: "{{ intellij_install_dir }}/bin"
+    creates: '{{ intellij_install_dir }}/bin'
     # Suppress: [WARNING]: Consider using unarchive module rather than running tar
     warn: no
 
 - name: create bin link
   become: yes
   file:
-    src: "{{ intellij_install_dir }}/bin/idea.sh"
+    src: '{{ intellij_install_dir }}/bin/idea.sh'
     dest: /usr/local/bin/idea
     state: link
     owner: root
@@ -80,7 +80,7 @@
   become: yes
   template:
     src: jetbrains-idea.desktop.j2
-    dest: "/usr/share/applications/{{ intellij_desktop_filename }}"
+    dest: '/usr/share/applications/{{ intellij_desktop_filename }}'
     owner: root
     group: root
     mode: 'u=rw,go=r'

--- a/vars/editions/community.yml
+++ b/vars/editions/community.yml
@@ -1,6 +1,6 @@
 ---
 # filename of IntelliJ IDEA redistributable package
-intellij_redis_filename: "ideaIC-{{ intellij_version }}.tar.gz"
+intellij_redis_filename: 'ideaIC-{{ intellij_version }}.tar.gz'
 
 # Name to use in the desktop link
 intellij_application_name: IntelliJ IDEA Community Edition

--- a/vars/editions/ultimate.yml
+++ b/vars/editions/ultimate.yml
@@ -1,6 +1,6 @@
 ---
 # filename of IntelliJ IDEA redistributable package
-intellij_redis_filename: "ideaIU-{{ intellij_version }}.tar.gz"
+intellij_redis_filename: 'ideaIU-{{ intellij_version }}.tar.gz'
 
 # Name to use in the desktop link
 intellij_application_name: IntelliJ IDEA

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 intellij_tmp_dir: "{{ ansible_env.HOME + '/.ansible/tmp' }}"
 
 # Location of install script for plugins
-intellij_plugin_install_script: "{{ intellij_tmp_dir }}/install-intellij-plugins.sh"
+intellij_plugin_install_script: '{{ intellij_tmp_dir }}/install-intellij-plugins.sh'
 
 # Location of sudo tty workaround
 intellij_sudo_tty_workaround: /etc/sudoers.d/10-intellij-plugin-installer-sudo-tty-workaround


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.