### PR TITLE
Removed intellij_jdk_home as it wasn't used

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ and code style):
 - hosts: servers
   roles:
     - role: gantsign.intellij
-      intellij_jdk_home: '/opt/java/oracle/jdk1.8.0_66'
       intellij_default_maven_home: '/opt/maven/apache-maven-3.3.9'
       users:
         - username: vagrant

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,11 +12,8 @@ intellij_edition: community
 # Base installation directory for any IntelliJ IDEA distribution
 intellij_install_dir: /opt/idea/idea-{{ intellij_edition }}-{{ intellij_version }}
 
-# Deprecated: split into intellij_jdk_home and users.intellij_jdks
+# Deprecated: use users.intellij_jdks and users.intellij_default_jdk instead
 intellij_default_jdk_home: '{{ ansible_local.java.general.home }}'
-
-# Location of the JDK for running IntelliJ IDEA
-intellij_jdk_home: '{{ intellij_default_jdk_home }}'
 
 # Location of the default Apache Maven installation for IntelliJ IDEA projects
 intellij_default_maven_home: '{{ ansible_local.maven.general.home }}'


### PR DESCRIPTION
It's best to stick with the built in JDK anyway as it has customizations from JetBrains to work better with IntelliJ.