### PR TITLE
Fixed support for plugins distributed as JARs

### DIFF
--- a/templates/install-intellij-plugins.sh.j2
+++ b/templates/install-intellij-plugins.sh.j2
@@ -49,11 +49,15 @@ download_plugin() {
         | grep -i --color=never 'Location') || return 2
     plugin_url=$(printf "$location_header" | awk '{print $2}') || return 2
 
-    if $(printf "$plugin_url" | grep --color=never --extended-regexp '^.*/([0-9]+)/([0-9]+)/([^/]+)$'); then
-        file_name=$(printf "$plugin_url" | sed --regexp-extended 's:^.*/([0-9]+)/([0-9]+)/([^/]+)$:\1-\2-\3:') || return 2
+    if [[ "$plugin_url" == *.jar ]]; then
+        file_name="${plugin_url##*/}"
     else
-        url_hash=$(printf "$plugin_url" | sha256sum | awk '{print $1}') || return 2
-        file_name=$plugin_id-$url_hash.zip
+        if $(printf "$plugin_url" | grep --color=never --extended-regexp '^.*/([0-9]+)/([0-9]+)/([^/]+)$'); then
+            file_name=$(printf "$plugin_url" | sed --regexp-extended 's:^.*/([0-9]+)/([0-9]+)/([^/]+)$:\1-\2-\3:') || return 2
+        else
+            url_hash=$(printf "$plugin_url" | sha256sum | awk '{print $1}') || return 2
+            file_name=$plugin_id-$url_hash.zip
+        fi
     fi
 
     file_path="$download_dir/$file_name"
@@ -94,13 +98,26 @@ install_plugin() {
     eval idea_user_home="$(printf "~%q" "$idea_user")"
     user_plugin_dir="$idea_user_home/$intellij_user_dir/config/plugins"
     sudo -H -u $idea_user mkdir -p $user_plugin_dir || return 2
-    zip_contents=$(unzip -Z1 "$file_path" | head -n 1) || return 2
 
-    if [ -e "$user_plugin_dir/$zip_contents" ]; then
-        exit_code=1
+    if [[ "$file_path" == *.jar ]]; then
+        file_name=$(basename "$file_path")
+        dest_path="$user_plugin_dir/$file_name"
+        if [ -e "$dest_path" ]; then
+            exit_code=1
+        else
+            cp "$file_path" "$dest_path" || return 2
+            chown "$idea_user:$idea_user" "$dest_path" || return 2
+            chmod 'ug=rw,o=r' "$dest_path" || return 2
+        fi
     else
-        sudo unzip "$file_path" -d $user_plugin_dir || return 2
-        (cd $user_plugin_dir && sudo unzip -Z1 "$file_path" | xargs -I '{}' chown "$idea_user:$idea_user" '{}')
+        zip_contents=$(unzip -Z1 "$file_path" | head -n 1) || return 2
+
+        if [ -e "$user_plugin_dir/$zip_contents" ]; then
+            exit_code=1
+        else
+            sudo unzip "$file_path" -d $user_plugin_dir || return 2
+            (cd $user_plugin_dir && sudo unzip -Z1 "$file_path" | xargs -I '{}' chown "$idea_user:$idea_user" '{}')
+        fi
     fi
 }
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -84,6 +84,7 @@
             - google-java-format
             - Lombook Plugin
             - ro.redeul.google.go
+            - com.dubreuia
         - username: test_usr2
           intellij_disabled_plugins:
           intellij_plugins:

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -45,3 +45,24 @@ def test_plugins_installed(Command, File, plugin_dir_name):
     assert plugin_dir.user == 'test_usr'
     assert plugin_dir.group == 'test_usr'
     assert oct(plugin_dir.mode) == '0755'
+
+
+def test_jar_plugin_installed(Command, File):
+    config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
+    config_home = Command.check_output('find %s | grep --color=never -E %s',
+                                       '/home/test_usr',
+                                       config_dir_pattern)
+
+    plugins_dir = config_home + '/plugins/'
+
+    plugin_path = Command.check_output('find %s | grep --color=never -E %s',
+                                       plugins_dir,
+                                       'save-actions_[0-9\\.]+.jar')
+
+    plugin_file = File(plugin_path)
+
+    assert plugin_file.exists
+    assert plugin_file.is_file
+    assert plugin_file.user == 'test_usr'
+    assert plugin_file.group == 'test_usr'
+    assert oct(plugin_file.mode) == '0664'


### PR DESCRIPTION
If a plugin is distributed as a JAR rather than a ZIP file it should not be unpacked.

Bug fix: resolves #98