### PR TITLE
Added support for Ultimate Edition license keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ users:
     intellij_active_codestyle: # Name (must match the value in the XML file /code_scheme/@name)
     intellij_plugins:
       - # Plugin ID of plugin to install
+    # Ultimate Edition only: location of the IntelliJ license key on the Ansible master.
+    # Your license key can be found at ~/.IntelliJIdea2017.1/config/idea.key
+    intellij_license_key_path: # e.g. '/vagrant/idea.key'
 ```
 
 **Warning:** the feature for installing additional plugins relies on internal

--- a/tasks/configure-license.yml
+++ b/tasks/configure-license.yml
@@ -1,0 +1,22 @@
+---
+- name: create IntelliJ IDEA user config directory
+  become: yes
+  file:
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config'
+    state: directory
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
+    mode: 'ug=rwx,o=rx'
+  with_items: '{{ users }}'
+
+- name: install license key
+  copy:
+    src: '{{ item.intellij_license_key_path }}'
+    dest: '~{{ item.username }}/{{ intellij_user_dir }}/config/idea.key'
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
+    mode: 'ug=rw,o=r'
+  with_items: '{{ users }}'
+  when:
+    - item.intellij_license_key_path is defined
+    - item.intellij_license_key_path not in ('', None, omit)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,6 @@
 ---
+- include: configure-license.yml
+
 - include: configure-disabled-plugins.yml
 
 - include: configure-jdk-table.yml


### PR DESCRIPTION
If you're using IntelliJ IDEA Ultimate Edition you can now configure this role to install your license key.