### PR TITLE
Fixed plugin downloads

### DIFF
--- a/templates/install-intellij-plugins.sh.j2
+++ b/templates/install-intellij-plugins.sh.j2
@@ -65,7 +65,7 @@ download_plugin() {
     if [ ! -f "$file_path" ]; then
         for i in {1..3}
         do
-            curl --silent --fail --output "$file_path" $plugin_url
+            curl --silent --fail --location --output "$file_path" $plugin_url
             if [ $? -eq 0 ]; then
                 break;
             fi


### PR DESCRIPTION
It seems JetBrains have moved the plugin hosting to S3 and now there's an additional redirect that needs to be followed.