### PR TITLE
Only download intellij when it isn't installed

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,6 +30,11 @@
     mode: 'u=rwx,go=rx'
     dest: '{{ intellij_download_dir }}'
 
+- name: Stat install dir
+  stat:
+    path: '{{ intellij_install_dir }}/bin'
+  register: stat_install_dir
+
 - name: download IntelliJ IDEA
   get_url:
     url: '{{ intellij_mirror }}/{{ intellij_redis_filename }}'
@@ -40,6 +45,7 @@
     validate_certs: yes
     timeout: '{{ intellij_idea_download_timeout_seconds }}'
     mode: 'u=rw,go=r'
+  when: not stat_install_dir.stat.exists
 
 - name: create IntelliJ IDEA installation directory
   become: yes


### PR DESCRIPTION
Previously, intellij was being downloaded regardless of whether it was
installed already or not. This checks whether the intellij bin directory
exists already, and skips the download if so. This is the same logic
used by the tar command in the 'install IntelliJ IDEA' task.