### PR TITLE
Use 'become' when installing plugin dependencies

### DIFF
--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -8,6 +8,7 @@
   when: ansible_pkg_mgr == 'yum'
 
 - name: install script dependencies
+  become: yes
   package:
     name: '{{ item }}'
     state: present


### PR DESCRIPTION
Installing packages requires root privileges