### PR TITLE
Remove Go plugin from tests

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -83,7 +83,6 @@
           intellij_plugins:
             - google-java-format
             - Lombook Plugin
-            - ro.redeul.google.go
             - com.dubreuia
         - username: test_usr2
           intellij_disabled_plugins:

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -30,8 +30,7 @@ def test_config_files(Command, File, file_path, expected_text):
 
 @pytest.mark.parametrize('plugin_dir_name', [
     'google-java-format',
-    'lombok-plugin',
-    'Go'
+    'lombok-plugin'
 ])
 def test_plugins_installed(Command, File, plugin_dir_name):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'


### PR DESCRIPTION
Updates have almost stopped since the official Go plugin was released.