### PR TITLE
Restored test for Google Format plugin

### DIFF
--- a/molecule/centos/playbook.yml
+++ b/molecule/centos/playbook.yml
@@ -57,8 +57,7 @@
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
           intellij_active_codestyle: GoogleStyle
           intellij_plugins:
-            # google-java-format is not vailable for 2018.1 yet, restore test when it is
-            # - google-java-format
+            - google-java-format
             - Lombook Plugin
             - com.dubreuia
         - username: test_usr2

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -56,8 +56,7 @@
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
           intellij_active_codestyle: GoogleStyle
           intellij_plugins:
-            # google-java-format is not vailable for 2018.1 yet, restore test when it is
-            # - google-java-format
+            - google-java-format
             - Lombook Plugin
             - com.dubreuia
         - username: test_usr2

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -31,9 +31,7 @@ def test_config_files(Command, File, file_path, expected_text):
 
 
 @pytest.mark.parametrize('plugin_dir_name', [
-    # google-java-format is not vailable for 2018.1 yet,
-    # restore test when it is.
-    # 'google-java-format',
+    'google-java-format',
     'lombok-plugin'
 ])
 def test_plugins_installed(Command, File, plugin_dir_name):

--- a/molecule/python3/playbook.yml
+++ b/molecule/python3/playbook.yml
@@ -55,8 +55,7 @@
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
           intellij_active_codestyle: GoogleStyle
           intellij_plugins:
-            # google-java-format is not vailable for 2018.1 yet, restore test when it is
-            # - google-java-format
+            - google-java-format
             - Lombook Plugin
             - com.dubreuia
         - username: test_usr2

--- a/molecule/ultimate/playbook.yml
+++ b/molecule/ultimate/playbook.yml
@@ -56,8 +56,7 @@
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
           intellij_active_codestyle: GoogleStyle
           intellij_plugins:
-            # google-java-format is not vailable for 2018.1 yet, restore test when it is
-            # - google-java-format
+            - google-java-format
             - Lombook Plugin
             - com.dubreuia
         - username: test_usr2


### PR DESCRIPTION
It's now available for IntelliJ 2018.1.