### PR TITLE
Use copy module to install code styles

### DIFF
--- a/tasks/install-code-styles.yml
+++ b/tasks/install-code-styles.yml
@@ -24,30 +24,11 @@
 
 - name: install codestyles
   become: yes
-  tags:
-    # False positive: [ANSIBLE0014] Environment variables don't work as part of command
-    # Since the environment variables are set in the script they work fine.
-    - skip_ansible_lint
-  shell: |
-    codestyle_src={{ intellij_download_dir }}/{{ item.1.url | regex_replace('^.*/([^/]+)$', '\1') }}
-    codestyle_dest=~{{ item.0.username }}/{{ intellij_user_dir }}/config/codestyles/{{ item.1.name }}.xml
-    [ -f $codestyle_dest ] && exit 1
-    cp --no-clobber $codestyle_src $codestyle_dest || exit 2
-  args:
-    executable: /bin/bash
-  with_subelements:
-    - '{{ users }}'
-    - intellij_codestyles
-    - skip_missing: yes
-  register: codestyle_copy
-  changed_when: codestyle_copy.rc == 0
-  failed_when: codestyle_copy.rc >= 2
-
-- name: set codestyles permissions
-  become: yes
-  file:
-    path: '~{{ item.0.username }}/{{ intellij_user_dir }}/config/codestyles/{{ item.1.name }}.xml'
-    state: file
+  copy:
+    src: "{{ intellij_download_dir }}/{{ item.1.url | regex_replace('^.*/([^/]+)$', '\\1') }}"
+    remote_src: yes
+    dest: '~{{ item.0.username }}/{{ intellij_user_dir }}/config/codestyles/{{ item.1.name }}.xml'
+    force: no
     owner: '{{ item.0.username }}'
     group: '{{ item.0.username }}'
     mode: 'ug=rw,o=r'


### PR DESCRIPTION
Now Ansible 2.3 is the minimum version for this role we can use `remote_src` of the copy module.