### PR TITLE
Renamed intellij_active_codestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ users:
     intellij_codestyles:
       - name: # Name (must match the value in the XML file /code_scheme/@name)
         url: # URL to download the codestyles XML from
-    intellij_active_codestyle: # Name (must match the value in the XML file /code_scheme/@name)
+    intellij_default_codestyle: # Name (must match the value in the XML file /code_scheme/@name)
     intellij_plugins:
       - # Plugin ID of plugin to install
     # Ultimate Edition only: location of the IntelliJ license key on the Ansible master.
@@ -242,7 +242,7 @@ and code style):
           intellij_codestyles:
             - name: GoogleStyle
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
-          intellij_active_codestyle: GoogleStyle
+          intellij_default_codestyle: GoogleStyle
           intellij_plugins:
             - CheckStyle-IDEA
 ```

--- a/molecule/centos/playbook.yml
+++ b/molecule/centos/playbook.yml
@@ -55,7 +55,7 @@
           intellij_codestyles:
             - name: GoogleStyle
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
-          intellij_active_codestyle: GoogleStyle
+          intellij_default_codestyle: GoogleStyle
           intellij_plugins:
             - google-java-format
             - Lombook Plugin

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -66,7 +66,7 @@
           intellij_codestyles:
             - name: GoogleStyle
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
-          intellij_active_codestyle: GoogleStyle
+          intellij_default_codestyle: GoogleStyle
           intellij_plugins:
             - google-java-format
             - Lombook Plugin

--- a/molecule/python3/playbook.yml
+++ b/molecule/python3/playbook.yml
@@ -87,7 +87,7 @@
           intellij_codestyles:
             - name: GoogleStyle
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
-          intellij_active_codestyle: GoogleStyle
+          intellij_default_codestyle: GoogleStyle
           intellij_plugins:
             - google-java-format
             - Lombook Plugin

--- a/molecule/ultimate/playbook.yml
+++ b/molecule/ultimate/playbook.yml
@@ -54,7 +54,7 @@
           intellij_codestyles:
             - name: GoogleStyle
               url: 'https://raw.githubusercontent.com/google/styleguide/gh-pages/intellij-java-google-style.xml'
-          intellij_active_codestyle: GoogleStyle
+          intellij_default_codestyle: GoogleStyle
           intellij_plugins:
             - google-java-format
             - Lombook Plugin

--- a/tasks/configure-code-style.yml
+++ b/tasks/configure-code-style.yml
@@ -19,7 +19,7 @@
     group: '{{ item.username }}'
     mode: 'ug=rw,o=r'
   with_items: '{{ users }}'
-  when: item.intellij_active_codestyle is defined
+  when: item.intellij_default_codestyle is defined or item.intellij_active_codestyle is defined
 
 - name: configure CodeStyleSchemeSettings
   become: yes
@@ -31,4 +31,4 @@
     group: '{{ item.username }}'
     mode: 'ug=rw,o=r'
   with_items: '{{ users }}'
-  when: item.intellij_active_codestyle is defined
+  when: item.intellij_default_codestyle is defined or item.intellij_active_codestyle is defined

--- a/templates/code.style.schemes.j2
+++ b/templates/code.style.schemes.j2
@@ -3,6 +3,6 @@
     <option name="PER_PROJECT_SETTINGS">
       <value />
     </option>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="{{ item.intellij_active_codestyle }}" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="{{ item.intellij_default_codestyle | default(item.intellij_active_codestyle) }}" />
   </component>
 </application>

--- a/templates/code.style.schemes.xml.j2
+++ b/templates/code.style.schemes.xml.j2
@@ -1,5 +1,5 @@
 <application>
   <component name="CodeStyleSchemeSettings">
-    <option name="CURRENT_SCHEME_NAME" value="{{ item.intellij_active_codestyle }}" />
+    <option name="CURRENT_SCHEME_NAME" value="{{ item.intellij_default_codestyle | default(item.intellij_active_codestyle) }}" />
   </component>
 </application>


### PR DESCRIPTION
Renamed `intellij_active_codestyle` to `intellij_default_codestyle`; it's more accurate and more consistent with the JDK property.