### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/centos/tests/test_role.py
+++ b/molecule/centos/tests/test_role.py
@@ -7,8 +7,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_idea_installed(Command):
-    assert Command('which idea').rc == 0
+def test_idea_installed(host):
+    assert host.run('which idea').rc == 0
 
 
 @pytest.mark.parametrize('file_path,expected_text', [
@@ -27,24 +27,24 @@ def test_idea_installed(Command):
     ('options/project.default.xml',
      'option name="PROJECT_PROFILE" value="GantSign"')
 ])
-def test_config_files(Command, File, file_path, expected_text):
+def test_config_files(host, file_path, expected_text):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
-    config_home = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       config_dir_pattern)
-    assert File(config_home + '/' + file_path).contains(expected_text)
+    config_home = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    config_dir_pattern)
+    assert host.file(config_home + '/' + file_path).contains(expected_text)
 
 
 @pytest.mark.parametrize('plugin_dir_name', [
     'google-java-format',
     'lombok-plugin'
 ])
-def test_plugins_installed(Command, File, plugin_dir_name):
+def test_plugins_installed(host, plugin_dir_name):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
-    config_home = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       config_dir_pattern)
-    plugin_dir = File(config_home + '/plugins/' + plugin_dir_name)
+    config_home = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    config_dir_pattern)
+    plugin_dir = host.file(config_home + '/plugins/' + plugin_dir_name)
 
     assert plugin_dir.exists
     assert plugin_dir.is_directory
@@ -53,19 +53,19 @@ def test_plugins_installed(Command, File, plugin_dir_name):
     assert plugin_dir.mode == 0o755
 
 
-def test_jar_plugin_installed(Command, File):
+def test_jar_plugin_installed(host):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
-    config_home = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       config_dir_pattern)
+    config_home = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    config_dir_pattern)
 
     plugins_dir = config_home + '/plugins/'
 
-    plugin_path = Command.check_output('find %s | grep --color=never -E %s',
-                                       plugins_dir,
-                                       'save-actions.*\\.jar')
+    plugin_path = host.check_output('find %s | grep --color=never -E %s',
+                                    plugins_dir,
+                                    'save-actions.*\\.jar')
 
-    plugin_file = File(plugin_path)
+    plugin_file = host.file(plugin_path)
 
     assert plugin_file.exists
     assert plugin_file.is_file

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -7,8 +7,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_idea_installed(Command):
-    assert Command('which idea').rc == 0
+def test_idea_installed(host):
+    assert host.run('which idea').rc == 0
 
 
 @pytest.mark.parametrize('file_path,expected_text', [
@@ -27,24 +27,24 @@ def test_idea_installed(Command):
     ('options/project.default.xml',
      'option name="PROJECT_PROFILE" value="GantSign"')
 ])
-def test_config_files(Command, File, file_path, expected_text):
+def test_config_files(host, file_path, expected_text):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
-    config_home = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       config_dir_pattern)
-    assert File(config_home + '/' + file_path).contains(expected_text)
+    config_home = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    config_dir_pattern)
+    assert host.file(config_home + '/' + file_path).contains(expected_text)
 
 
 @pytest.mark.parametrize('plugin_dir_name', [
     'google-java-format',
     'lombok-plugin'
 ])
-def test_plugins_installed(Command, File, plugin_dir_name):
+def test_plugins_installed(host, plugin_dir_name):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
-    config_home = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       config_dir_pattern)
-    plugin_dir = File(config_home + '/plugins/' + plugin_dir_name)
+    config_home = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    config_dir_pattern)
+    plugin_dir = host.file(config_home + '/plugins/' + plugin_dir_name)
 
     assert plugin_dir.exists
     assert plugin_dir.is_directory
@@ -53,19 +53,19 @@ def test_plugins_installed(Command, File, plugin_dir_name):
     assert plugin_dir.mode == 0o755
 
 
-def test_jar_plugin_installed(Command, File):
+def test_jar_plugin_installed(host):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
-    config_home = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       config_dir_pattern)
+    config_home = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    config_dir_pattern)
 
     plugins_dir = config_home + '/plugins/'
 
-    plugin_path = Command.check_output('find %s | grep --color=never -E %s',
-                                       plugins_dir,
-                                       'save-actions.*\\.jar')
+    plugin_path = host.check_output('find %s | grep --color=never -E %s',
+                                    plugins_dir,
+                                    'save-actions.*\\.jar')
 
-    plugin_file = File(plugin_path)
+    plugin_file = host.file(plugin_path)
 
     assert plugin_file.exists
     assert plugin_file.is_file

--- a/molecule/minimal/tests/test_role.py
+++ b/molecule/minimal/tests/test_role.py
@@ -7,5 +7,5 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_idea_installed(Command):
-    assert Command('which idea').rc == 0
+def test_idea_installed(host):
+    assert host.run('which idea').rc == 0


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.