### PR TITLE
Workaround bug in AdoptOpenJDK API

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -38,7 +38,7 @@
 
     - name: download jdk 10
       get_url:
-        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-10.0.1%2B10&type=jdk'
+        url: 'https://github.com/AdoptOpenJDK/openjdk10-releases/releases/download/jdk-10.0.1%2B10/OpenJDK10_x64_Linux_201807101745.tar.gz'
         dest: '/opt/java/jdk-10.tar.gz'
         force: no
         use_proxy: yes

--- a/molecule/python3/playbook.yml
+++ b/molecule/python3/playbook.yml
@@ -32,7 +32,7 @@
 
     - name: download jdk 10
       get_url:
-        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-10.0.1%2B10&type=jdk'
+        url: 'https://github.com/AdoptOpenJDK/openjdk10-releases/releases/download/jdk-10.0.1%2B10/OpenJDK10_x64_Linux_201807101745.tar.gz'
         dest: '/opt/java/jdk-10.tar.gz'
         force: no
         use_proxy: yes

--- a/molecule/ultimate/playbook.yml
+++ b/molecule/ultimate/playbook.yml
@@ -32,7 +32,7 @@
 
     - name: download jdk 10
       get_url:
-        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-10.0.1%2B10&type=jdk'
+        url: 'https://github.com/AdoptOpenJDK/openjdk10-releases/releases/download/jdk-10.0.1%2B10/OpenJDK10_x64_Linux_201807101745.tar.gz'
         dest: '/opt/java/jdk-10.tar.gz'
         force: no
         use_proxy: yes


### PR DESCRIPTION
The API isn't working with named releases.