### PR TITLE
Improve messages about invalid JDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ Requirements
 
 * Java JDK
 
+    * You need to install the JDK src as well as the JDK.
+    * When using Java > 9 you also need to install the jmods.
+
+    e.g. the following is required if using OpenJDK 11 with CentOS:
+
+    ```yml
+    - name: Install OpenJDK 11
+      become: true
+      yum:
+        name:
+          - java-11-openjdk-devel
+          - java-11-openjdk-jmods
+          - java-11-openjdk-src
+        state: present
+    ```
+
 * Apache Maven
 
 Role Variables

--- a/library/intellij_configure_jdk.py
+++ b/library/intellij_configure_jdk.py
@@ -126,7 +126,10 @@ def get_class_path(module, jdk_home):
         return "\n".join(elements)
 
     else:
-        module.fail_json(msg='Unsupported JDK directory layout: %s' % jdk_home)
+        module.fail_json(msg=("Unsupported JDK directory layout: %s. If you're "
+                              "using Java > 9 you may need to install the "
+                              "jmods package e.g. yum install "
+                              "java-11-openjdk-jmods.") % jdk_home)
 
 
 def get_source_path(module, jdk_home):
@@ -173,7 +176,10 @@ def get_source_path(module, jdk_home):
         return "\n".join(elements)
 
     else:
-        module.fail_json(msg='Unsupported JDK directory layout: %s' % jdk_home)
+        module.fail_json(msg=("Unsupported JDK directory layout: %s. You may "
+                              "need to install the src package for the JDK "
+                              "e.g. yum install "
+                              "java-11-openjdk-src.") % jdk_home)
 
 
 def create_jdk_xml(module, intellij_user_dir, jdk_name, jdk_home):

--- a/library/intellij_configure_jdk.py
+++ b/library/intellij_configure_jdk.py
@@ -176,10 +176,7 @@ def get_source_path(module, jdk_home):
         return "\n".join(elements)
 
     else:
-        module.fail_json(msg=("Unsupported JDK directory layout: %s. You may "
-                              "need to install the src package for the JDK "
-                              "e.g. yum install "
-                              "java-11-openjdk-src.") % jdk_home)
+        module.fail_json(msg='Directory not found: %s' % jdk_home)
 
 
 def create_jdk_xml(module, intellij_user_dir, jdk_name, jdk_home):

--- a/molecule/centos/playbook.yml
+++ b/molecule/centos/playbook.yml
@@ -21,10 +21,13 @@
         name: which
         state: present
 
-    - name: install jdk 8
+    - name: install jdk 11
       become: yes
       yum:
-        name: java-1.8.0-openjdk-devel
+        name:
+          - java-11-openjdk-devel
+          - java-11-openjdk-jmods
+          - java-11-openjdk-src
         state: present
 
     - name: install jdk 7
@@ -36,7 +39,7 @@
     - name: set facts for openjdk locations
       set_fact:
         jdk7_home: '/usr/lib/jvm/java-1.7.0-openjdk'
-        jdk8_home: '/usr/lib/jvm/java-1.8.0-openjdk'
+        jdk11_home: '/usr/lib/jvm/java-11-openjdk'
 
   roles:
     - role: ansible-role-intellij
@@ -45,11 +48,11 @@
       users:
         - username: test_usr
           intellij_jdks:
-            - name: '1.8'
-              home: '{{ jdk8_home }}'
+            - name: '11'
+              home: '{{ jdk11_home }}'
             - name: '1.7'
               home: '{{ jdk7_home }}'
-          intellij_default_jdk: '1.8'
+          intellij_default_jdk: '11'
           intellij_disabled_plugins:
             - org.jetbrains.plugins.gradle
           intellij_codestyles:

--- a/molecule/centos/tests/test_role.py
+++ b/molecule/centos/tests/test_role.py
@@ -13,7 +13,7 @@ def test_idea_installed(host):
 
 @pytest.mark.parametrize('file_path,expected_text', [
     ('disabled_plugins.txt', 'org.jetbrains.plugins.gradle'),
-    ('options/jdk.table.xml', '/usr/lib/jvm/java-1.8.0-openjdk'),
+    ('options/jdk.table.xml', '/usr/lib/jvm/java-11-openjdk'),
     ('options/jdk.table.xml', '/usr/lib/jvm/java-1.7.0-openjdk'),
     ('options/project.default.xml', '/test/maven/home'),
     ('codestyles/GoogleStyle.xml', 'code_scheme name="GoogleStyle"'),


### PR DESCRIPTION
Installing the JDK by itself often isn't enough.

Fix: resolves #220