### PR TITLE
Updated tests to use Java 11.0.6

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -43,8 +43,8 @@
 
     - name: download jdk 11
       get_url:
-        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-11%2B28&type=jdk'
-        dest: '/opt/java/jdk-11.tar.gz'
+        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-11.0.6%2B10&type=jdk'
+        dest: '/opt/java/jdk-11.0.6.tar.gz'
         force: no
         use_proxy: yes
         validate_certs: yes
@@ -54,17 +54,17 @@
     - name: install jdk 11
       become: yes
       unarchive:
-        src: '/opt/java/jdk-11.tar.gz'
+        src: '/opt/java/jdk-11.0.6.tar.gz'
         remote_src: yes
         dest: '/opt/java'
         owner: root
         group: root
-        creates: '/opt/java/jdk-11+28/bin'
+        creates: '/opt/java/jdk-11.0.6+10/bin'
 
     - name: set facts for openjdk locations
       set_fact:
         jdk8_home: '/usr/lib/jvm/java-1.8.0-openjdk-amd64'
-        jdk11_home: '/opt/java/jdk-11+28'
+        jdk11_home: '/opt/java/jdk-11.0.6+10'
 
   roles:
     - role: ansible-role-intellij

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -14,7 +14,7 @@ def test_idea_installed(host):
 @pytest.mark.parametrize('file_path,expected_text', [
     ('disabled_plugins.txt', 'org.jetbrains.plugins.gradle'),
     ('options/jdk.table.xml', '/usr/lib/jvm/java-1.8.0-openjdk'),
-    ('options/jdk.table.xml', '/opt/java/jdk-11+28'),
+    ('options/jdk.table.xml', '/opt/java/jdk-11.0.6+10'),
     ('options/project.default.xml', '/test/maven/home'),
     ('codestyles/GoogleStyle.xml', 'code_scheme name="GoogleStyle"'),
     ('options/code.style.schemes',

--- a/molecule/python3/playbook.yml
+++ b/molecule/python3/playbook.yml
@@ -37,8 +37,8 @@
 
     - name: download jdk 11
       get_url:
-        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-11%2B28&type=jdk'
-        dest: '/opt/java/jdk-11.tar.gz'
+        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-11.0.6%2B10&type=jdk'
+        dest: '/opt/java/jdk-11.0.6.tar.gz'
         force: no
         use_proxy: yes
         validate_certs: yes
@@ -48,17 +48,17 @@
     - name: install jdk 11
       become: yes
       unarchive:
-        src: '/opt/java/jdk-11.tar.gz'
+        src: '/opt/java/jdk-11.0.6.tar.gz'
         remote_src: yes
         dest: '/opt/java'
         owner: root
         group: root
-        creates: '/opt/java/jdk-11+28/bin'
+        creates: '/opt/java/jdk-11.0.6+10/bin'
 
     - name: set facts for openjdk locations
       set_fact:
         jdk8_home: '/usr/lib/jvm/java-1.8.0-openjdk-amd64'
-        jdk11_home: '/opt/java/jdk-11+28'
+        jdk11_home: '/opt/java/jdk-11.0.6+10'
 
   roles:
     - role: ansible-role-intellij

--- a/molecule/ultimate/playbook.yml
+++ b/molecule/ultimate/playbook.yml
@@ -37,8 +37,8 @@
 
     - name: download jdk 11
       get_url:
-        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-11%2B28&type=jdk'
-        dest: '/opt/java/jdk-11.tar.gz'
+        url: 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk-11.0.6%2B10&type=jdk'
+        dest: '/opt/java/jdk-11.0.6.tar.gz'
         force: no
         use_proxy: yes
         validate_certs: yes
@@ -48,17 +48,17 @@
     - name: install jdk 11
       become: yes
       unarchive:
-        src: '/opt/java/jdk-11.tar.gz'
+        src: '/opt/java/jdk-11.0.6.tar.gz'
         remote_src: yes
         dest: '/opt/java'
         owner: root
         group: root
-        creates: '/opt/java/jdk-11+28/bin'
+        creates: '/opt/java/jdk-11.0.6+10/bin'
 
     - name: set facts for openjdk locations
       set_fact:
         jdk8_home: '/usr/lib/jvm/java-1.8.0-openjdk-amd64'
-        jdk11_home: '/opt/java/jdk-11+28'
+        jdk11_home: '/opt/java/jdk-11.0.6+10'
 
   roles:
     - role: ansible-role-intellij


### PR DESCRIPTION
It appears Java 11.0.0 is no longer available from AdoptOpenJDK.