### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: IntelliJ
 ======================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-intellij.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-intellij)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-intellij.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-intellij)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.intellij-blue.svg)](https://galaxy.ansible.com/gantsign/intellij)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-intellij/master/LICENSE)
 


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.