### PR TITLE
Fixed get_url.sha256sum deprecation warning

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,7 +45,7 @@
   get_url:
     url: '{{ intellij_mirror }}/{{ intellij_redis_filename }}'
     dest: '{{ intellij_download_dir }}/{{ intellij_redis_filename }}'
-    sha256sum: '{{ intellij_redis_sha256sum }}'
+    checksum: 'sha256:{{ intellij_redis_sha256sum }}'
     force: no
     use_proxy: yes
     validate_certs: yes


### PR DESCRIPTION
```
[DEPRECATION WARNING]: The parameter "sha256sum" has been deprecated and will
be removed, use "checksum" instead. This feature will be removed from ansible-
base in version 2.14. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```