### PR TITLE
Fixed install for plugins with missing dirs in zip

### DIFF
--- a/library/intellij_install_plugin.py
+++ b/library/intellij_install_plugin.py
@@ -131,7 +131,10 @@ def extract_zip(module, output_dir, zipfile_path, uid, gid):
 
     for file_entry in files:
         absolute_file = os.path.join(output_dir, file_entry)
-        os.chown(absolute_file, uid, gid)
+        while not os.path.samefile(absolute_file, output_dir):
+            os.chown(absolute_file, uid, gid)
+            absolute_file = os.path.normpath(
+                os.path.join(absolute_file, os.pardir))
 
 
 def fetch_url(module, url, method=None, timeout=10, follow_redirects=True):

--- a/molecule/centos/converge.yml
+++ b/molecule/centos/converge.yml
@@ -65,7 +65,7 @@
           intellij_default_inspection_profile: GantSign
           intellij_plugins:
             - google-java-format
-            - Lombook Plugin
+            - MavenRunHelper
             - com.dubreuia
         - username: test_usr2
           intellij_disabled_plugins:

--- a/molecule/centos/tests/test_role.py
+++ b/molecule/centos/tests/test_role.py
@@ -32,7 +32,7 @@ def test_config_files(host, file_path, expected_text):
 
 @pytest.mark.parametrize('plugin_dir_name', [
     'google-java-format',
-    'lombok-plugin'
+    'MavenRunHelper'
 ])
 def test_plugins_installed(host, plugin_dir_name):
     plugins_dir_pattern = (

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -97,7 +97,7 @@
           intellij_default_inspection_profile: GantSign
           intellij_plugins:
             - google-java-format
-            - Lombook Plugin
+            - MavenRunHelper
             - com.dubreuia
         - username: test_usr2
           intellij_disabled_plugins:

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -32,7 +32,7 @@ def test_config_files(host, file_path, expected_text):
 
 @pytest.mark.parametrize('plugin_dir_name', [
     'google-java-format',
-    'lombok-plugin'
+    'MavenRunHelper'
 ])
 def test_plugins_installed(host, plugin_dir_name):
     plugins_dir_pattern = (

--- a/molecule/opensuse/converge.yml
+++ b/molecule/opensuse/converge.yml
@@ -69,7 +69,7 @@
           intellij_default_inspection_profile: GantSign
           intellij_plugins:
             - google-java-format
-            - Lombook Plugin
+            - MavenRunHelper
             - com.dubreuia
         - username: test_usr2
           intellij_group: users

--- a/molecule/opensuse/tests/test_role.py
+++ b/molecule/opensuse/tests/test_role.py
@@ -32,7 +32,7 @@ def test_config_files(host, file_path, expected_text):
 
 @pytest.mark.parametrize('plugin_dir_name', [
     'google-java-format',
-    'lombok-plugin'
+    'MavenRunHelper'
 ])
 def test_plugins_installed(host, plugin_dir_name):
     plugins_dir_pattern = (

--- a/molecule/ultimate/converge.yml
+++ b/molecule/ultimate/converge.yml
@@ -91,7 +91,7 @@
           intellij_default_inspection_profile: GantSign
           intellij_plugins:
             - google-java-format
-            - Lombook Plugin
+            - MavenRunHelper
             - com.dubreuia
         - username: test_usr2
           intellij_disabled_plugins:


### PR DESCRIPTION
The install was failing to set the ownership unless the directory is an entry in the zip file.