### PR TITLE
Updated to IntelliJ version 2021.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2021.1.1'
+intellij_version: '2021.1.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2021.1.2`
 * `2021.1.1`
 * `2021.1`
 * `2020.3.3`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2021.1.1'
+intellij_version: '2021.1.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2021.1.2-community.yml
+++ b/vars/versions/2021.1.2-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: e2517d79b39581f1548ca4119cb2fa478505cf73203d97b4f3292f05ae71250e

--- a/vars/versions/2021.1.2-ultimate.yml
+++ b/vars/versions/2021.1.2-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: e90e814c9ef629c35bd6aa95b63c5fc48d8eaba78b41deed2557902f7021871f


### PR DESCRIPTION
2021.1.2 is now the default version installed.