### PR TITLE
Update 2021.1.3-community.yml

### DIFF
--- a/vars/versions/2021.1.3-community.yml
+++ b/vars/versions/2021.1.3-community.yml
@@ -1,3 +1,3 @@
 ---
 # SHA256 sum for the redistributable package
-intellij_redis_sha256sum: c17a4755ebbd6e459924f56b3a20aea09151adb66b647e8c241b78a67baf045f
+intellij_redis_sha256sum: b14ed5fbd9c7523a1fd2e689b0ac8bc990c046b92bd6699548efcc11937217de

--- a/vars/versions/2021.1.3-ultimate.yml
+++ b/vars/versions/2021.1.3-ultimate.yml
@@ -1,3 +1,3 @@
 ---
 # SHA256 sum for the redistributable package
-intellij_redis_sha256sum: 47ec0973666bc7179d814be1c6ce1a5ac354860fbf92afa644da919b5d814d67
+intellij_redis_sha256sum: 39be57e086f2dcb489d3eb1ba0e8e88db0ab242f4e5e29e0e7985d2caef894aa


### PR DESCRIPTION
This sha seems to be wrong when I download it, I get a sha256sum of b14ed5fbd9c7523a1fd2e689b0ac8bc990c046b92bd6699548efcc11937217de