### PR TITLE
Updated to IntelliJ version 2021.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2021.2.1'
+intellij_version: '2021.2.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2021.2.2`
 * `2021.2.1`
 * `2021.2`
 * `2021.1.3`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2021.2.1'
+intellij_version: '2021.2.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2021.2.2-community.yml
+++ b/vars/versions/2021.2.2-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 919002deb71b764aa2a072996d07338294f1a2ea8ea0028f036f01296bf5a96f

--- a/vars/versions/2021.2.2-ultimate.yml
+++ b/vars/versions/2021.2.2-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 36807af6a60a31590fb51f40a87c764007dae6866b05586ebb15d2d13933bde6


### PR DESCRIPTION
2021.2.2 is now the default version installed.