### PR TITLE
Updated to IntelliJ version 2021.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2021.2.2'
+intellij_version: '2021.2.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2021.2.3`
 * `2021.2.2`
 * `2021.2.1`
 * `2021.2`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2021.2.2'
+intellij_version: '2021.2.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2021.2.3-community.yml
+++ b/vars/versions/2021.2.3-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 582eb0b6dc9cb3c181d179638ccae54a89cfe73bd59fac6806c4fee8b586d998

--- a/vars/versions/2021.2.3-ultimate.yml
+++ b/vars/versions/2021.2.3-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 16929fd22b84b400d0b9e24fd356dd2e7a614511a2d779ee37082c90df179c25


### PR DESCRIPTION
2021.2.3 is now the default version installed.