### PR TITLE
Replaced CentOS 7 tests with Rocky Linux 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Requirements
 
     * RedHat Family
 
-        * CentOS
+        * Rocky Linux
 
-            * 7
+            * 8
 
     * Note: other versions are likely to work but have not been tested.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
+        - 8
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/centos/converge.yml
+++ b/molecule/centos/converge.yml
@@ -30,15 +30,15 @@
           - java-11-openjdk-src
         state: present
 
-    - name: install jdk 7
+    - name: install jdk 8
       become: yes
       yum:
-        name: java-1.7.0-openjdk-devel
+        name: java-1.8.0-openjdk-devel
         state: present
 
     - name: set facts for openjdk locations
       set_fact:
-        jdk7_home: '/usr/lib/jvm/java-1.7.0-openjdk'
+        jdk8_home: '/usr/lib/jvm/java-1.8.0-openjdk'
         jdk11_home: '/usr/lib/jvm/java-11-openjdk'
 
   roles:
@@ -50,8 +50,8 @@
           intellij_jdks:
             - name: '11'
               home: '{{ jdk11_home }}'
-            - name: '1.7'
-              home: '{{ jdk7_home }}'
+            - name: '1.8'
+              home: '{{ jdk8_home }}'
           intellij_default_jdk: '11'
           intellij_disabled_plugins:
             - org.jetbrains.plugins.gradle

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-intellij-community-centos
-    image: centos:7
+    image: rockylinux/rockylinux:8
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:

--- a/molecule/centos/tests/test_role.py
+++ b/molecule/centos/tests/test_role.py
@@ -8,7 +8,7 @@ def test_idea_installed(host):
 @pytest.mark.parametrize('file_path,expected_text', [
     ('disabled_plugins.txt', 'org.jetbrains.plugins.gradle'),
     ('options/jdk.table.xml', '/usr/lib/jvm/java-11-openjdk'),
-    ('options/jdk.table.xml', '/usr/lib/jvm/java-1.7.0-openjdk'),
+    ('options/jdk.table.xml', '/usr/lib/jvm/java-1.8.0-openjdk'),
     ('options/project.default.xml', '/test/maven/home'),
     ('codestyles/GoogleStyle.xml', 'code_scheme name="GoogleStyle"'),
     ('options/code.style.schemes',


### PR DESCRIPTION
RedHat have discontinued the downstream version of CentOS.