### PR TITLE
Updated to IntelliJ version 2021.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2021.3.1'
+intellij_version: '2021.3.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2021.3.2`
 * `2021.3.1`
 * `2021.3`
 * `2021.2.3`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2021.3.1'
+intellij_version: '2021.3.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2021.3.2-community.yml
+++ b/vars/versions/2021.3.2-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 99e2225846d118e3190023abc65c8b2c62a1d1463f601c79a20b9494c54a08c9

--- a/vars/versions/2021.3.2-ultimate.yml
+++ b/vars/versions/2021.3.2-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 0b3230fbd899cc82377c2be0fb036337202f341c3c236252dd8eedc37248341c


### PR DESCRIPTION
2021.3.2 is now the default version installed.