### PR TITLE
Updated to IntelliJ version 2022.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.1.1'
+intellij_version: '2022.1.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.1.2`
 * `2022.1.1`
 * `2022.1`
 * `2021.3.3`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.1.1'
+intellij_version: '2022.1.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.1.2-community.yml
+++ b/vars/versions/2022.1.2-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: f587f7d83ab464014314d5c44b5baf873369ce4b2091f16a461bb4180f752c97

--- a/vars/versions/2022.1.2-ultimate.yml
+++ b/vars/versions/2022.1.2-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 539b3f08364d48574d65a50588a8376477c72246ad003f272675c2fca66f09d1


### PR DESCRIPTION
2022.1.2 is now the default version installed.