### PR TITLE
Updated to IntelliJ version 2022.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.1.2'
+intellij_version: '2022.1.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.1.3`
 * `2022.1.2`
 * `2022.1.1`
 * `2022.1`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.1.2'
+intellij_version: '2022.1.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.1.3-community.yml
+++ b/vars/versions/2022.1.3-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: f8a14e3ab100cf745dc7e329e13bd31961cd728c6b7676493b9ffb4e290a9543

--- a/vars/versions/2022.1.3-ultimate.yml
+++ b/vars/versions/2022.1.3-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: bf0248e520364dcecb2a1b1fd6b0d209c755e06711ccf75589c255de3501b37a


### PR DESCRIPTION
2022.1.3 is now the default version installed.