### PR TITLE
Updated to IntelliJ version 2022.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.1.3'
+intellij_version: '2022.1.4'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.1.4`
 * `2022.1.3`
 * `2022.1.2`
 * `2022.1.1`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.1.3'
+intellij_version: '2022.1.4'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.1.4-community.yml
+++ b/vars/versions/2022.1.4-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: c61a922cdd8b452ecbaa397dcbbc87946b6e2e5b972a58f8f1d39f6f4994e3c8

--- a/vars/versions/2022.1.4-ultimate.yml
+++ b/vars/versions/2022.1.4-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: f9e9389f0184306cae8d8b464a7c9b5baabb3a10a526a76fa7f0e3b44a158b8d


### PR DESCRIPTION
2022.1.4 is now the default version installed.