### PR TITLE
Updated to IntelliJ version 2022.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.1.4'
+intellij_version: '2022.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.2`
 * `2022.1.4`
 * `2022.1.3`
 * `2022.1.2`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.1.4'
+intellij_version: '2022.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.2-community.yml
+++ b/vars/versions/2022.2-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: bbec46c56ae7c6fe92f2a16af0e3bd6a4c50786198535d368030ee24e520b997

--- a/vars/versions/2022.2-ultimate.yml
+++ b/vars/versions/2022.2-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 15654e4b0b27f56427184ceefe5229f2a644218f83dfd735b0e8dcb7041610e7


### PR DESCRIPTION
2022.2 is now the default version installed.