### PR TITLE
Updated to IntelliJ version 2022.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.2'
+intellij_version: '2022.2.1'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.2.1`
 * `2022.2`
 * `2022.1.4`
 * `2022.1.3`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.2'
+intellij_version: '2022.2.1'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.2.1-community.yml
+++ b/vars/versions/2022.2.1-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 93eb9391a898aad164ca47965e0445cbf0f04d7062b6875c4e4a3136799ee6cf

--- a/vars/versions/2022.2.1-ultimate.yml
+++ b/vars/versions/2022.2.1-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 69d3600b94cdd45a0954d7424e6e87d86fb4c86f64974ff678ba6a4e2a885c47


### PR DESCRIPTION
2022.2.1 is now the default version installed.