### PR TITLE
Updated to IntelliJ version 2022.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.2.1'
+intellij_version: '2022.2.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -130,6 +130,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.2.2`
 * `2022.2.1`
 * `2022.2`
 * `2022.1.4`
@@ -331,7 +332,7 @@ This role exports the following Ansible facts for use by other roles:
 
 * `ansible_local.intellij.general.home`
 
-    * e.g. `/opt/idea/idea-community-2022.2.1`
+    * e.g. `/opt/idea/idea-community-2022.2.2`
 
 * `ansible_local.intellij.general.desktop_filename`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.2.1'
+intellij_version: '2022.2.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.2.2-community.yml
+++ b/vars/versions/2022.2.2-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: c16fcdb1c6d72369642b98b9425eae932834b17687ea231204b30ed813333aff

--- a/vars/versions/2022.2.2-ultimate.yml
+++ b/vars/versions/2022.2.2-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: bbc1793715c7a75228de6914bea0a881d982d38da3b48b89df08f08fbe8e5e54


### PR DESCRIPTION
2022.2.2 is now the default version installed.