### PR TITLE
Updated to IntelliJ version 2022.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.3.1'
+intellij_version: '2022.3.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -138,6 +138,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.3.2`
 * `2022.3.1`
 * `2022.3`
 * `2022.2.4`
@@ -354,7 +355,7 @@ This role exports the following Ansible facts for use by other roles:
 
 * `ansible_local.intellij.general.home`
 
-    * e.g. `/opt/idea/idea-community-2022.3.1`
+    * e.g. `/opt/idea/idea-community-2022.3.2`
 
 * `ansible_local.intellij.general.desktop_filename`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.3.1'
+intellij_version: '2022.3.2'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.3.2-community.yml
+++ b/vars/versions/2022.3.2-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 02bc35281eb4e1285eeb9d797ec2b31ec7370e320ad0e89f6f1fa704d78ec4bf

--- a/vars/versions/2022.3.2-ultimate.yml
+++ b/vars/versions/2022.3.2-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 6fa3aff1c730bb79bf3e2e29edcce6d4cdbccfa631524c6253de518be6b6f3d2


### PR DESCRIPTION
2022.3.2 is now the default version installed.