### PR TITLE
Updated to IntelliJ version 2022.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ are shown below):
 
 ```yaml
 # IntelliJ IDEA version number
-intellij_version: '2022.3.2'
+intellij_version: '2022.3.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579
@@ -138,6 +138,7 @@ The following versions of IntelliJ IDEA are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `2022.3.3`
 * `2022.3.2`
 * `2022.3.1`
 * `2022.3`
@@ -355,7 +356,7 @@ This role exports the following Ansible facts for use by other roles:
 
 * `ansible_local.intellij.general.home`
 
-    * e.g. `/opt/idea/idea-community-2022.3.2`
+    * e.g. `/opt/idea/idea-community-2022.3.3`
 
 * `ansible_local.intellij.general.desktop_filename`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # IntelliJ IDEA version number
-intellij_version: '2022.3.2'
+intellij_version: '2022.3.3'
 
 # Mirror where to dowload IntelliJ IDEA redistributable package from
 # Using HTTP because of https://github.com/ansible/ansible/issues/11579

--- a/vars/versions/2022.3.3-community.yml
+++ b/vars/versions/2022.3.3-community.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: 699492fb5a9de750250fdaadca5fc9212114ee445a50875b59bbc99f0187c2e4

--- a/vars/versions/2022.3.3-ultimate.yml
+++ b/vars/versions/2022.3.3-ultimate.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+intellij_redis_sha256sum: c302bd84b48a56ef1b0f033e8e93a0da5590f80482eae172db6130da035314a6


### PR DESCRIPTION
2022.3.3 is now the default version installed.