### PR TITLE
Migrated to new Save Actions Plugin

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -125,7 +125,7 @@
           intellij_plugins:
             - google-java-format
             - MavenRunHelper
-            - com.dubreuia
+            - software.xdev.saveactions
         - username: test_usr2
           intellij_disabled_plugins:
           intellij_plugins: []

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -70,4 +70,4 @@ def test_jar_plugin_installed(host):
     assert plugin_file.is_file
     assert plugin_file.user == 'test_usr'
     assert plugin_file.group == 'test_usr'
-    assert plugin_file.mode == 0o664
+    assert plugin_file.mode == 0o644

--- a/molecule/opensuse/converge.yml
+++ b/molecule/opensuse/converge.yml
@@ -71,7 +71,7 @@
           intellij_plugins:
             - google-java-format
             - MavenRunHelper
-            - com.dubreuia
+            - software.xdev.saveactions
         - username: test_usr2
           intellij_group: users
           intellij_disabled_plugins:

--- a/molecule/opensuse/tests/test_role.py
+++ b/molecule/opensuse/tests/test_role.py
@@ -66,4 +66,4 @@ def test_jar_plugin_installed(host):
     assert plugin_file.is_file
     assert plugin_file.user == 'test_usr'
     assert plugin_file.group == 'users'
-    assert plugin_file.mode == 0o664
+    assert plugin_file.mode == 0o644

--- a/molecule/rocky/converge.yml
+++ b/molecule/rocky/converge.yml
@@ -67,7 +67,7 @@
           intellij_plugins:
             - google-java-format
             - MavenRunHelper
-            - com.dubreuia
+            - software.xdev.saveactions
         - username: test_usr2
           intellij_disabled_plugins:
           intellij_plugins: []

--- a/molecule/rocky/tests/test_role.py
+++ b/molecule/rocky/tests/test_role.py
@@ -66,4 +66,4 @@ def test_jar_plugin_installed(host):
     assert plugin_file.is_file
     assert plugin_file.user == 'test_usr'
     assert plugin_file.group == 'test_usr'
-    assert plugin_file.mode == 0o664
+    assert plugin_file.mode == 0o644

--- a/molecule/ultimate/converge.yml
+++ b/molecule/ultimate/converge.yml
@@ -119,7 +119,7 @@
           intellij_plugins:
             - google-java-format
             - MavenRunHelper
-            - com.dubreuia
+            - software.xdev.saveactions
         - username: test_usr2
           intellij_disabled_plugins:
           intellij_plugins: []


### PR DESCRIPTION
`com.dubreuia` is deprecated, moved to `software.xdev.saveactions` fork.