### PR TITLE
Fixed color output when running GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   PY_COLORS: '1'
-  ANSIBLE_FORCE_COLOR: '1'
 
 jobs:
   lint:
@@ -43,7 +42,7 @@ jobs:
         run: pip3 install --no-compile -r requirements/tox.txt
 
       - name: Lint
-        run: tox run -e lint
+        run: tox --colored=yes run -e lint
 
       - name: Compact lint cache
         if: steps.lint-cache.outputs.cache-hit != 'true'
@@ -107,7 +106,7 @@ jobs:
         run: pip3 install --no-compile -r requirements/tox.txt
 
       - name: Molecule test
-        run: tox run -e ansible-${{ matrix.ansible-version }} -- --scenario-name=${{ matrix.molecule-scenario }}
+        run: tox --colored=yes run -e ansible-${{ matrix.ansible-version }} -- --scenario-name=${{ matrix.molecule-scenario }}
 
       - name: Compact Molecule cache
         if: steps.molecule-cache.outputs.cache-hit != 'true'

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ deps =
     ansible-max: -r requirements/ansible-max.txt
 commands =
     molecule test {posargs}
+setenv =
+    PY_COLORS = 1
+    ANSIBLE_FORCE_COLOR = 1
 
 [testenv:lint]
 description = runs lint checks on the role
@@ -23,6 +26,9 @@ commands =
     yamllint .
     ansible-lint .
     flake8 --exclude .tox,.venv
+setenv =
+    PY_COLORS = 1
+    ANSIBLE_FORCE_COLOR = 1
 
 [testenv:dev]
 description = dependencies for development


### PR DESCRIPTION
Was broken by move to `tox`.