### PR TITLE
Dropped support for Ubuntu Bionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Requirements
 
         * Ubuntu
 
-            * Bionic (18.04)
             * Focal (20.04)
             * Jammy (22.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
         - focal
         - jammy
   galaxy_tags:

--- a/molecule/ultimate/molecule.yml
+++ b/molecule/ultimate/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-intellij-ultimate-ubuntu
-    image: ubuntu:18.04
+    image: ubuntu:20.04
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Bionic.